### PR TITLE
Standardize library import statements

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
 import sys
-from window import Window
+
 from utils import readInputData
+from window import Window
 
 if __name__ == "__main__":
     # get dir name from CLI args

--- a/window.py
+++ b/window.py
@@ -1,15 +1,16 @@
 """Define the GUI windows class using TKinter."""
 
-import sys
 import os
+import sys
 from datetime import datetime
+
 # import tkinter depends on py version
 if sys.version_info.major > 2:
     import tkinter as tk
-    from tkinter import ttk, messagebox
+    from tkinter import messagebox, ttk
 else:
     import Tkinter as tk
-    from TKinter import ttk, messagebox
+    from TKinter import messagebox, ttk
 
 
 class Window(tk.Tk):


### PR DESCRIPTION
Implement the usage of `isort` to always have a standard order for the import statements.