### PR TITLE
Apply clear selection after a move operation and refactor move_items function

### DIFF
--- a/window.py
+++ b/window.py
@@ -142,6 +142,9 @@ class Window(tk.Tk):
         # update the StringVar
         left_lvar.set(left_lst)
         
+        # clear the current selection to start fresh for the next move
+        left_lb.select_clear(0, tk.END)
+        
     def clear_selection(self):
         """Clears the current selection of the input listbox."""
         


### PR DESCRIPTION
Fixes issue #4 : after performing a move operation, the ListBox selection is cleared in order to provide a cleaner UI.

Also refactors the `move_items` functionality into 2 separate functions:
- `move_items()` function which handles a generic move of specified items from a left list to a right list (i.e. adds items to the right list and removes them from the left list)
- `move_items_dir()` function which figures out if the move is input-to-output or output-to-input and calls the `move_items()` with the correct parameters