### PR TITLE
Implement a file picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,26 +4,32 @@ A simple Python GUI to select certain lines from `csv` files found inside the fo
 Can also change the value of certain fields.
 The selected data can be exported to an output `csv` file.
 
-## Installation
+## Installation & Usage
 
 The simplest way to get started with this project is to use the `pixi` package manager.
 Follow the instructions provided [here](https://pixi.sh/dev/installation/) to install `pixi` on your platform.
 (Optionally, one can also use `pixi` to install `git`, if needed, via `pixi global install --expose git git`.)
 
+To start the project, use the following steps:
 ```bash
 # clone the git repo
 git clone https://github.com/irinaene/spreadsheet-gui.git
 # move to the repo dir
 cd spreadsheet-gui
-# install the pixi environment
+# start the default task
+pixi run start
+```
+
+It is also possible to use the script directly from the CLI with the following steps:
+```bash
+# clone the git repo
+git clone https://github.com/irinaene/spreadsheet-gui.git
+# move to the repo dir
+cd spreadsheet-gui
+# install the environment (only need to do this once)
 pixi install
 # "activate" the environment
 pixi shell
-```
-
-## Usage
-
-Assuming the `csv` files live inside `input_dir`, the GUI can be started with
-```bash
-python gui.py input_dir
+# run the GUI script
+python gui.py input_dir  # assumes csv files are located inside input_dir
 ```

--- a/gui.py
+++ b/gui.py
@@ -1,18 +1,35 @@
 #!/usr/bin/env python
 
+import os
 import sys
+from tkinter.filedialog import askdirectory
 
 from utils import readInputData
 from window import Window
 
 if __name__ == "__main__":
-    # get dir name from CLI args
-    input_dir = sys.argv[1]
     # create the GUI object
     window = Window()
+    # open window on top
+    window.focus_force()
+    # run mainloop once to update position of window (otherwise filedialog will mess up the geom)
+    window.update_idletasks()
+    
+    # check if using script with file picker or in CLI mode
+    if len(sys.argv) == 1:
+        # get starting directory for open dialog box
+        curr_dir = os.getcwd()
+        # get files from open dialog
+        input_dir = askdirectory(initialdir=curr_dir, title="Select Folder", parent=window)
+    else:
+        # get dir name from CLI args
+        input_dir = sys.argv[1]
+    
     # read input data and format appropriately
     data_lst, format_dict = readInputData(input_dir=input_dir)
+    
     # add data to the GUI
     window.importData(data_lst, format_dict=format_dict)
+    
     # run the main tkinter loop
     window.mainloop()

--- a/pixi.toml
+++ b/pixi.toml
@@ -7,6 +7,7 @@ version = "0.1.0"
 
 [tasks]
 test = "python gui.py test_data"
+start = "python gui.py"
 
 [dependencies]
 python = "3.10.*"

--- a/utils.py
+++ b/utils.py
@@ -19,6 +19,8 @@ def readInputData(input_dir, desc_len=50, cat_len=20):
     files.extend(glob.glob(f"{input_dir}/*.CSV"))
     # on windows, glob + wildcard returns duplicates, fix by using set to select unique values
     files = list(set(files))
+    # always open files in same order
+    files = sorted(files)
     # add header with column descriptions, nicely formatted
     c1 = "Date".ljust(date_len)
     c2 = "Description".ljust(desc_len)

--- a/window.py
+++ b/window.py
@@ -18,7 +18,12 @@ class Window(tk.Tk):
         super().__init__()
         
         # set window properties
-        self.geometry('1700x800+300+300')
+        width, height = 1700, 800
+        screen_width = self.winfo_screenwidth()
+        screen_height = self.winfo_screenheight()
+        x = (screen_width - width) // 2
+        y = (screen_height - height) // 2
+        self.geometry(f"{width}x{height}+{x}+{y}")
         self.title('Spreadsheet GUI')
         
         # set some default max display lengths for list items


### PR DESCRIPTION
Adds a `filedialog` window to choose which folder the `csv` files live in -- this is the default behavior when starting the GUI with `pixi run start`; closes #8.

Also adds improvements to the default position of the GUI window on opening (now it's centered on the screen) and makes sure the `csv` files are always loaded in the same order.